### PR TITLE
Resolvido capybara ambiguous match

### DIFF
--- a/app/views/clients/sessions/new.html.erb
+++ b/app/views/clients/sessions/new.html.erb
@@ -19,7 +19,7 @@
   <% end %>
 
   <div class="actions">
-    <%= f.submit "Entrar" %>
+    <%= f.submit "Login" %>
   </div>
 <% end %>
 

--- a/config/locales/client.pt-BR.yml
+++ b/config/locales/client.pt-BR.yml
@@ -2,7 +2,7 @@ pt-BR:
   clients:
    registrations:
     new:
-       submit: Registrar
+       submit: Cadastrar
   activerecord:
     models:
       client: Cliente

--- a/spec/features/client/client_login_spec.rb
+++ b/spec/features/client/client_login_spec.rb
@@ -7,7 +7,7 @@ feature 'Client login on system' do
     click_on 'Entrar'
     fill_in 'CPF', with: cliente.cpf
     fill_in 'Senha', with: cliente.password
-    click_on 'Entrar'
+    click_on 'Login'
 
     expect(page).to have_content('Login efetuado com sucesso')
   end
@@ -18,7 +18,7 @@ feature 'Client login on system' do
     click_on 'Entrar'
     fill_in 'CPF', with: ''
     fill_in 'Senha', with: cliente.password
-    click_on 'Entrar'
+    click_on 'Login'
 
     expect(page).to have_content('CPF ou senha inválidos.')
   end

--- a/spec/features/client/client_register_spec.rb
+++ b/spec/features/client/client_register_spec.rb
@@ -8,7 +8,7 @@ feature 'Visitor creates Account' do
     fill_in 'Email', with: 'test@email.com'
     fill_in 'Senha', with: '12345678'
     fill_in 'Confirme sua senha', with: '12345678'
-    click_on 'Registrar'
+    click_on 'Cadastrar'
 
     expect(page).to have_content('Bem vindo! Você realizou seu registro com sucesso.')
   end
@@ -18,7 +18,7 @@ feature 'Visitor creates Account' do
     fill_in 'CPF', with: ''
     fill_in 'Email', with: ''
     fill_in 'Senha', with: ''
-    click_on 'Registrar'
+    click_on 'Cadastrar'
 
     expect(page).to have_content('não pode ficar em branco', count: 3)
     expect(page).to have_content('Email não pode ficar em branco')
@@ -32,7 +32,7 @@ feature 'Visitor creates Account' do
     fill_in 'Email', with: 'test@email.com'
     fill_in 'Senha', with: '12345678'
     fill_in 'Confirme sua senha', with: '12345678'
-    click_on 'Registrar'
+    click_on 'Cadastrar'
 
     expect(page).to have_content('CPF precisa ser válido')
   end
@@ -44,7 +44,7 @@ feature 'Visitor creates Account' do
     fill_in 'Email', with: 'test@email.com'
     fill_in 'Senha', with: '12345678'
     fill_in 'Confirme sua senha', with: '12345678'
-    click_on 'Registrar'
+    click_on 'Cadastrar'
 
     expect(page).to have_content('CPF já está em uso')
   end


### PR DESCRIPTION
Co-authored-by Antony anthonynakamoto@gmail.com  fix #24

Foram alterados os nomes dos botões de Entrar para Login e Registrar para Cadastrar, isso resolveu o ambiguous match