### PR TITLE
Add alguns breadcrumbs

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,10 +1,19 @@
 class ApplicationController < ActionController::Base
   before_action :configure_permitted_parameters, if: :devise_controller?
+  before_action :set_breadcrumbs
 
   protected
 
   def configure_permitted_parameters
     devise_parameter_sanitizer.permit(:sign_up, keys: %i[email name cpf cref])
     devise_parameter_sanitizer.permit(:account_update, keys: %i[email name])
+  end
+
+  def add_breadcrumb(label, path = nil)
+    @breadcrumbs << { label: label, path: path }
+  end
+
+  def set_breadcrumbs
+    @breadcrumbs = []
   end
 end

--- a/app/controllers/enrolls_controller.rb
+++ b/app/controllers/enrolls_controller.rb
@@ -22,7 +22,8 @@ class EnrollsController < ApplicationController
   end
 
   def confirm
-    add_breadcrumb('Matrícula')
+    add_breadcrumb('Matrícula', new_subsidiary_enroll_path(params[:subsidiary_id]))
+    add_breadcrumb('Confirmar')
     @enroll = Enroll.new(enroll_params_confirm)
     return if @enroll.valid?
 
@@ -56,6 +57,10 @@ class EnrollsController < ApplicationController
 
   def add_subsidiary_breadcrumb
     @subsidiary = Subsidiary.find(params[:subsidiary_id])
-    add_breadcrumb(@subsidiary.name, subsidiary_path(@subsidiary.id))
+    if @subsidiary
+      add_breadcrumb(@subsidiary.name, subsidiary_path(@subsidiary.id))
+    else
+      add_breadcrumb('Filial')
+    end
   end
 end

--- a/app/controllers/enrolls_controller.rb
+++ b/app/controllers/enrolls_controller.rb
@@ -1,8 +1,10 @@
 class EnrollsController < ApplicationController
   before_action :authenticate_client!
   before_action :check_already_enrolled
+  before_action :add_subsidiary_breadcrumb, only: %i[new confirm]
 
   def new
+    add_breadcrumb('Matrícula')
     @enroll = Enroll.new
     @subsidiary = Subsidiary.find(params[:subsidiary_id])
     @payment_options = PaymentOption.all
@@ -20,6 +22,7 @@ class EnrollsController < ApplicationController
   end
 
   def confirm
+    add_breadcrumb('Matrícula')
     @enroll = Enroll.new(enroll_params_confirm)
     return if @enroll.valid?
 
@@ -49,5 +52,10 @@ class EnrollsController < ApplicationController
     else
       redirect_to root_path, notice: t('.subsidiary_not_found')
     end
+  end
+
+  def add_subsidiary_breadcrumb
+    @subsidiary = Subsidiary.find(params[:subsidiary_id])
+    add_breadcrumb(@subsidiary.name, subsidiary_path(@subsidiary.id))
   end
 end

--- a/app/controllers/subsidiaries_controller.rb
+++ b/app/controllers/subsidiaries_controller.rb
@@ -1,9 +1,11 @@
 class SubsidiariesController < ApplicationController
   def show
     @subsidiary = Subsidiary.find(params[:id])
+    add_breadcrumb(@subsidiary.name, subsidiary_path)
   end
 
   def search
+    add_breadcrumb('Busca')
     @subsidiaries = Subsidiary.search(params[:q])
   end
 end

--- a/app/controllers/subsidiaries_controller.rb
+++ b/app/controllers/subsidiaries_controller.rb
@@ -1,7 +1,7 @@
 class SubsidiariesController < ApplicationController
   def show
     @subsidiary = Subsidiary.find(params[:id])
-    add_breadcrumb(@subsidiary.name, subsidiary_path)
+    add_breadcrumb(@subsidiary.name)
   end
 
   def search

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -22,7 +22,7 @@
       <%= link_to 'Registrar', new_client_registration_path %>
       <%= link_to 'Entrar', new_client_session_path %>
     <% end %>
-    
+    <%= render 'shared/breadcrumbs' %>
     <%= link_to 'Minha Agenda', appointments_path if personal_signed_in? %>
 
     <p class="notice"><%= notice %></p>

--- a/app/views/shared/_breadcrumbs.html.erb
+++ b/app/views/shared/_breadcrumbs.html.erb
@@ -1,0 +1,16 @@
+<nav aria-label="breadcrumb">
+  <ol class="breadcrumb">
+    <li class="breadcrumb-item"><%= link_to 'Home', root_path %></li>
+    <% @breadcrumbs.each do |breadcrumb| %>
+      <%  if breadcrumb[:path].nil? %>
+        <li class="breadcrumb-item active" aria-current="page">
+          <%= breadcrumb[:label] %>
+        </li>
+      <% else %>
+        <li class="breadcrumb-item">
+          <%= link_to breadcrumb[:label], breadcrumb[:path] %>
+        </li>
+      <% end %>
+    <% end %>
+  </ol>
+</nav>

--- a/app/views/shared/_breadcrumbs.html.erb
+++ b/app/views/shared/_breadcrumbs.html.erb
@@ -1,8 +1,10 @@
 <nav aria-label="breadcrumb">
   <ol class="breadcrumb">
-    <li class="breadcrumb-item"><%= link_to 'Home', root_path %></li>
+    <li class="breadcrumb-item">
+      <%= link_to 'Home', root_path %>
+    </li>
     <% @breadcrumbs.each do |breadcrumb| %>
-      <%  if breadcrumb[:path].nil? %>
+      <% if breadcrumb[:path].nil? %>
         <li class="breadcrumb-item active" aria-current="page">
           <%= breadcrumb[:label] %>
         </li>

--- a/spec/features/breadcrumbs_spec.rb
+++ b/spec/features/breadcrumbs_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+feature 'Breadcrumbs' do
+  context 'subsidiaries and enroll' do
+    scenario 'show' do
+      visit root_path
+      click_on 'Vila Maria'
+
+      expect(page).to have_link('Home', href: root_path)
+      expect(page).to have_content('Home Vila Maria')
+      expect(page).to_not have_content('Home Matrícula')
+    end
+
+    scenario 'search' do
+      visit root_path
+      click_on 'Buscar'
+
+      expect(page).to have_link('Home', href: root_path)
+      expect(page).to have_content('Home Busca')
+      expect(page).to_not have_content('Home Vila Maria')
+    end
+
+    scenario 'enroll' do
+      client = create(:client)
+
+      login_as(client, scope: :client)
+      visit root_path
+      click_on 'Vila Maria'
+      click_on 'Matricule-se'
+
+      expect(page).to have_link('Home', href: root_path)
+      expect(page).to have_link('Vila Maria')
+      expect(page).to have_content('Home Vila Maria Matrícula')
+      expect(page).to_not have_content('Home Busca')
+    end
+  end
+end

--- a/spec/features/breadcrumbs_spec.rb
+++ b/spec/features/breadcrumbs_spec.rb
@@ -33,5 +33,27 @@ feature 'Breadcrumbs' do
       expect(page).to have_content('Home Vila Maria Matrícula')
       expect(page).to_not have_content('Home Busca')
     end
+
+    scenario 'confirm enroll' do
+      client = create(:client)
+      create(:payment_option)
+      subsidiary = Subsidiary.new(id: 1, name: 'Vila Maria',
+                                  address: 'Avenida Osvaldo Reis, 801', cep: '88306-773')
+      allow(Subsidiary).to receive(:all).and_return([subsidiary])
+
+      login_as(client, scope: :client)
+      visit root_path
+      click_on 'Vila Maria'
+      click_on 'Matricule-se'
+      select 'Esperto', from: 'Plano'
+      select 'Boleto', from: 'Forma de pagamento'
+      click_on 'Próximo'
+
+      expect(page).to have_link('Home', href: root_path)
+      expect(page).to have_link('Vila Maria', href: subsidiary_path(subsidiary.id))
+      expect(page).to have_link('Matrícula', href: new_subsidiary_enroll_path(subsidiary.id))
+      expect(page).to have_content('Home Vila Maria Matrícula Confirmar')
+      expect(page).to_not have_content('Home Busca')
+    end
   end
 end

--- a/spec/requests/enroll_subsidiary_authorization_spec.rb
+++ b/spec/requests/enroll_subsidiary_authorization_spec.rb
@@ -3,9 +3,10 @@ require 'rails_helper'
 describe 'Enroll subsidiary' do
   context 'confirm' do
     let(:subsidiary) do
-      Subsidiary.new(id: 1, name: 'Vila Maria',
-                     address: 'Avenida Osvaldo Reis, 801', cep: '88306-773')
+      Subsidiary.new(id: 1, address: 'Avenida Osvaldo Reis, 801',
+                     name: 'Vila Maria', cep: '88306-773')
     end
+
     it 'must be logged in to post confirm' do
       post subsidiary_enrolls_confirm_path(subsidiary.id)
 
@@ -37,8 +38,6 @@ describe 'Enroll subsidiary' do
     it 'with valid params' do
       client = create(:client)
       payment_option = create(:payment_option)
-      subsidiary = Subsidiary.new(id: 1, name: 'Vila Maria',
-                                  address: 'Avenida Osvaldo Reis, 801', cep: '88306-773')
       plan = Plan.new(id: 1, name: 'Black', monthly_payment: 120.00, permanency: 12,
                       subsidiary: subsidiary)
       enroll = Enroll.new(subsidiary_id: subsidiary.id, plan_id: plan.id,


### PR DESCRIPTION
Breadcrumbs são tipo o caminho que você vai deixando enquanto clica nos links.
Por exemplo, a gente está em home, clica no nome de uma filial e clica em matricular.
Com os breadcrumbs, vai adicionando uma barrinha no alto tipo
Home / Filial / Matricular
Perceba que se tiver breadcrumbs bonitinhos em todos os caminhos, não precisa mais de botão voltar, dado que eles já fazem isso.

Teria que colocar isso em todos os lugares, por enquanto só tem nos caminhos que passam por uma subsidiary.

Fix #53 